### PR TITLE
Include Rubra AI versions of the Phi-3 model for text-to-sql use case

### DIFF
--- a/luna-llm-serve/ray-service.llm.Phi-3-mini-128k-instruct-tools-16k-4-gpus.yaml
+++ b/luna-llm-serve/ray-service.llm.Phi-3-mini-128k-instruct-tools-16k-4-gpus.yaml
@@ -1,4 +1,4 @@
-# Note: derived from: https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/ai-ml/gke-ray/rayserve/llm/
+#r Note: derived from: https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/ai-ml/gke-ray/rayserve/llm/
 
 apiVersion: ray.io/v1
 kind: RayService
@@ -11,11 +11,13 @@ spec:
     applications:
     - name: llm
       route_prefix: /
-      import_path:  luna-llm-serve.llm:build_app
+      import_path:  phi3models.llm:build_app
       args:
-        model: "microsoft/Phi-3-mini-4k-instruct"
-        tensor-parallel-size: "1"
-        dtype: "bfloat16"
+        model: "rubra-ai/Phi-3-mini-128k-instruct"
+        tensor-parallel-size: "4"
+        dtype: "float16"
+        max_model_len: "16384"
+        max_num_seqs: "2"
       deployments:
       - name: VLLMDeployment
         num_replicas: 1
@@ -23,11 +25,11 @@ spec:
           num_cpus: 1
           # NOTE: num_gpus is set automatically based on TENSOR_PARALLELISM
       runtime_env:
-        working_dir: "https://github.com/elotl/skyray/archive/main.zip"
+        working_dir: "https://github.com/elotl/modelexpt/archive/main.zip"
         pip: ["vllm==0.5.4"]
         env_vars:
-          MODEL_ID: "microsoft/Phi-3-mini-4k-instruct"
-          TENSOR_PARALLELISM: "1"
+          MODEL_ID: "rubra-ai/Phi-3-mini-128k-instruct"
+          TENSOR_PARALLELISM: "4"
   rayClusterConfig:
     headGroupSpec:
       rayStartParams:
@@ -58,7 +60,7 @@ spec:
               name: serve
     workerGroupSpecs:
     - replicas: 1
-      minReplicas: 0
+      minReplicas: 1
       maxReplicas: 4
       groupName: gpu-group
       rayStartParams: {}
@@ -75,12 +77,12 @@ spec:
             resources:
               limits:
                 cpu: "8"
-                memory: "20Gi"
-                nvidia.com/gpu: "1"
+                memory: "30Gi"
+                nvidia.com/gpu: "4"
               requests:
                 cpu: "8"
-                memory: "20Gi"
-                nvidia.com/gpu: "1"
+                memory: "30Gi"
+                nvidia.com/gpu: "4"
           tolerations:
             - key: nvidia.com/gpu
               effect: NoSchedule

--- a/luna-llm-serve/ray-service.llm.Phi-3-mini-128k-instruct-tools-8k.yaml
+++ b/luna-llm-serve/ray-service.llm.Phi-3-mini-128k-instruct-tools-8k.yaml
@@ -1,4 +1,4 @@
-# Note: derived from: https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/ai-ml/gke-ray/rayserve/llm/
+#r Note: derived from: https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/ai-ml/gke-ray/rayserve/llm/
 
 apiVersion: ray.io/v1
 kind: RayService
@@ -11,11 +11,14 @@ spec:
     applications:
     - name: llm
       route_prefix: /
-      import_path:  luna-llm-serve.llm:build_app
+      import_path:  phi3models.llm:build_app
       args:
-        model: "microsoft/Phi-3-mini-4k-instruct"
+        model: "rubra-ai/Phi-3-mini-128k-instruct"
         tensor-parallel-size: "1"
         dtype: "bfloat16"
+        gpu-memory-utilization: "0.9"
+        max_model_len: "8192"
+        max_num_seqs: "2"
       deployments:
       - name: VLLMDeployment
         num_replicas: 1
@@ -23,10 +26,10 @@ spec:
           num_cpus: 1
           # NOTE: num_gpus is set automatically based on TENSOR_PARALLELISM
       runtime_env:
-        working_dir: "https://github.com/elotl/skyray/archive/main.zip"
-        pip: ["vllm==0.5.4"]
+        working_dir: "https://github.com/elotl/modelexpt/archive/main.zip"
+        pip: ["vllm==0.7.2"]
         env_vars:
-          MODEL_ID: "microsoft/Phi-3-mini-4k-instruct"
+          MODEL_ID: "rubra-ai/Phi-3-mini-128k-instruct"
           TENSOR_PARALLELISM: "1"
   rayClusterConfig:
     headGroupSpec:
@@ -58,7 +61,7 @@ spec:
               name: serve
     workerGroupSpecs:
     - replicas: 1
-      minReplicas: 0
+      minReplicas: 1
       maxReplicas: 4
       groupName: gpu-group
       rayStartParams: {}
@@ -75,11 +78,11 @@ spec:
             resources:
               limits:
                 cpu: "8"
-                memory: "20Gi"
+                memory: "30Gi"
                 nvidia.com/gpu: "1"
               requests:
                 cpu: "8"
-                memory: "20Gi"
+                memory: "30Gi"
                 nvidia.com/gpu: "1"
           tolerations:
             - key: nvidia.com/gpu


### PR DESCRIPTION
This PR makes the following changes:

1. Include the Rubra AI versions of the Phi-3 model that is customized for funtion-calling or tool-calling. This is needed for the text to SQL use case in the GenAI Infra repo: https://github.com/elotl/GenAI-infra-stack Rubra model details can be found here: https://docs.rubra.ai/models/Phi/ and https://huggingface.co/rubra-ai/Phi-3-mini-128k-instruct
Two versions of this model have been included:
            a) Max model len of 8k
            b) Max model len of 16k and parallelized to run on 4 GPUs.
            
2. gpu-memory-utilizaion field was removed from the base Phi3 model. (so default value of 0.9 will come into effect) This helped decrease inference latency considerably in experiments.