### PR TITLE
[WIP] Kserve on nova

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ kubectl apply -f policies/inferenceservicepolicy.yaml
 ### 6. Deploy an InferenceService
 
 ```bash
-export SKYRAY_PATH=$(pwd)
 export APP_NAMESPACE=default
 export INFERENCE_SERVICE_NAME=my-model
 bash deploy-scripts/deploy-inferenceservice.sh
 ```
+
+> No need to set `SKYRAY_PATH` — the script resolves paths relative to its own location.
 
 Or apply the sample directly:
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,17 @@ Install in this order against the Nova control plane:
 ### 1. Prerequisites
 
 - **Nova** control plane and workload clusters must be set up and running
-- **cert-manager** must be installed on the workload clusters (required by KServe webhooks)
+- **cert-manager** must be installed on the **workload clusters** (required by KServe webhooks)
+
+> **Note:** Because Nova cannot run pods:
+> The deploy script installs only cert-manager **CRDs** on the Nova control plane (so helm
+> can create Certificate/Issuer resources). Full cert-manager must already be running on
+> the workload clusters where KServe pods will actually execute.
+
+Install cert-manager **directly** on each workload cluster (not through the Nova control plane):
 
 ```bash
-➜ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.0/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
 ```
 
 ### 2. Apply Nova Spread Policies
@@ -38,7 +45,9 @@ kubectl apply -f deploy-scripts/kservenamespace.yaml
 bash deploy-scripts/deploy-kserve.sh
 ```
 
-This installs the `kserve-crd` and `kserve` helm charts, then labels CRDs and operator resources so the spread policies pick them up.
+This installs cert-manager CRDs (so helm can create Certificate/Issuer resources on the Nova control plane),
+then installs the `kserve-crd` and `kserve` helm charts, and labels CRDs and operator resources so the
+spread policies pick them up.
 
 ### 5. Apply InferenceService Placement Policy
 
@@ -79,8 +88,8 @@ bash deploy-scripts/undeploy-kserve.sh
 
 | File | Purpose |
 |------|---------|
-| `deploy-scripts/deploy-kserve.sh` | Install KServe CRDs + operator, label resources for Nova |
-| `deploy-scripts/undeploy-kserve.sh` | Uninstall KServe and delete CRDs |
+| `deploy-scripts/deploy-kserve.sh` | Install cert-manager CRDs + KServe CRDs + operator, label resources for Nova |
+| `deploy-scripts/undeploy-kserve.sh` | Uninstall KServe, delete KServe CRDs and cert-manager CRDs |
 | `deploy-scripts/kservenamespace.yaml` | KServe namespace with `app: kserve` label |
 | `deploy-scripts/deploy-inferenceservice.sh` | Deploy and label an InferenceService CR |
 | `deploy-scripts/inference-service.sample.yaml` | Sample InferenceService template |

--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@ Install in this order against the Nova control plane:
 ### 1. Prerequisites
 
 - **Nova** control plane and workload clusters must be set up and running
-- **cert-manager** must be installed on the **workload clusters** (required by KServe webhooks)
+- **cert-manager** must be installed **directly** on the workload clusters (required by KServe webhooks)
 
-> **Note:** Because Nova cannot run pods:
-> The deploy script installs only cert-manager **CRDs** on the Nova control plane (so helm
-> can create Certificate/Issuer resources). Full cert-manager must already be running on
-> the workload clusters where KServe pods will actually execute.
+> **Note:** Nova cannot run pods, so the deploy script disables cert-manager integration
+> (`kserve.certManager.enabled=false`) on the Nova control plane. KServe and cert-manager
+> will function normally on the workload clusters where pods actually execute.
 
 Install cert-manager **directly** on each workload cluster (not through the Nova control plane):
 
@@ -45,9 +44,8 @@ kubectl apply -f deploy-scripts/kservenamespace.yaml
 bash deploy-scripts/deploy-kserve.sh
 ```
 
-This installs cert-manager CRDs (so helm can create Certificate/Issuer resources on the Nova control plane),
-then installs the `kserve-crd` and `kserve` helm charts, and labels CRDs and operator resources so the
-spread policies pick them up.
+This installs the `kserve-crd` and `kserve` helm charts (with cert-manager disabled for the Nova control plane),
+then labels CRDs and operator resources so the spread policies pick them up.
 
 ### 5. Apply InferenceService Placement Policy
 
@@ -88,8 +86,8 @@ bash deploy-scripts/undeploy-kserve.sh
 
 | File | Purpose |
 |------|---------|
-| `deploy-scripts/deploy-kserve.sh` | Install cert-manager CRDs + KServe CRDs + operator, label resources for Nova |
-| `deploy-scripts/undeploy-kserve.sh` | Uninstall KServe, delete KServe CRDs and cert-manager CRDs |
+| `deploy-scripts/deploy-kserve.sh` | Install KServe CRDs + operator (cert-manager disabled), label resources for Nova |
+| `deploy-scripts/undeploy-kserve.sh` | Uninstall KServe and delete KServe CRDs |
 | `deploy-scripts/kservenamespace.yaml` | KServe namespace with `app: kserve` label |
 | `deploy-scripts/deploy-inferenceservice.sh` | Deploy and label an InferenceService CR |
 | `deploy-scripts/inference-service.sample.yaml` | Sample InferenceService template |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,91 @@
 # skyray
 Support interoperation of KubeRay with Nova and Luna
+
+# KServe
+
+## Nova + KServe Quick Start
+
+Install in this order against the Nova control plane:
+
+### 1. Prerequisites
+
+- **Nova** control plane and workload clusters must be set up and running
+- **cert-manager** must be installed on the workload clusters (required by KServe webhooks)
+
+```bash
+➜ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.0/cert-manager.yaml
+```
+
+### 2. Apply Nova Spread Policies
+
+These tell Nova to duplicate KServe CRDs, namespace, and operator components to all workload clusters:
+
+```bash
+kubectl apply -f policies/kservecrdpolicy.yaml
+kubectl apply -f policies/kservenspolicy.yaml
+kubectl apply -f policies/kservepolicy.yaml
+```
+
+### 3. Create the KServe Namespace
+
+```bash
+kubectl apply -f deploy-scripts/kservenamespace.yaml
+```
+
+### 4. Deploy KServe (CRDs + Operator)
+
+```bash
+bash deploy-scripts/deploy-kserve.sh
+```
+
+This installs the `kserve-crd` and `kserve` helm charts, then labels CRDs and operator resources so the spread policies pick them up.
+
+### 5. Apply InferenceService Placement Policy
+
+Choose one of the placement policies for InferenceService CRs:
+
+```bash
+# For kind testing (targets kind-workload-2):
+kubectl apply -f policies/inferenceservicepolicy.yaml
+
+# Or for namespace-scoped priority placement (also set to kind-workload-2 for testing;
+# see commented-out orderedClusterSelector for production onprem→cloud ordering):
+# export APP_NAMESPACE=my-app
+# envsubst < policies/inferenceservicensprioritypolicy.yaml | kubectl apply -f -
+```
+
+### 6. Deploy an InferenceService
+
+```bash
+export SKYRAY_PATH=$(pwd)
+export APP_NAMESPACE=default
+export INFERENCE_SERVICE_NAME=my-model
+bash deploy-scripts/deploy-inferenceservice.sh
+```
+
+Or apply the sample directly:
+
+```bash
+kubectl apply -f deploy-scripts/inference-service.sample.yaml
+```
+
+### Teardown
+
+```bash
+bash deploy-scripts/undeploy-kserve.sh
+```
+
+## Files Reference
+
+| File | Purpose |
+|------|---------|
+| `deploy-scripts/deploy-kserve.sh` | Install KServe CRDs + operator, label resources for Nova |
+| `deploy-scripts/undeploy-kserve.sh` | Uninstall KServe and delete CRDs |
+| `deploy-scripts/kservenamespace.yaml` | KServe namespace with `app: kserve` label |
+| `deploy-scripts/deploy-inferenceservice.sh` | Deploy and label an InferenceService CR |
+| `deploy-scripts/inference-service.sample.yaml` | Sample InferenceService template |
+| `policies/kservecrdpolicy.yaml` | Spread KServe CRDs to all clusters |
+| `policies/kservenspolicy.yaml` | Spread KServe namespace to all clusters |
+| `policies/kservepolicy.yaml` | Spread KServe operator to all clusters |
+| `policies/inferenceservicepolicy.yaml` | Place InferenceService on a target cluster |
+| `policies/inferenceservicensprioritypolicy.yaml` | Place InferenceService with cluster priority |

--- a/deploy-scripts/deploy-inferenceservice.sh
+++ b/deploy-scripts/deploy-inferenceservice.sh
@@ -1,0 +1,2 @@
+envsubst < ${SKYRAY_PATH}/deploy-scripts/inference-service.sample.yaml | kubectl apply -n ${APP_NAMESPACE} -f -
+kubectl label inferenceservices.serving.kserve.io/${INFERENCE_SERVICE_NAME} -n ${APP_NAMESPACE} app.kubernetes.io/instance=inferenceservice

--- a/deploy-scripts/deploy-inferenceservice.sh
+++ b/deploy-scripts/deploy-inferenceservice.sh
@@ -1,2 +1,3 @@
-envsubst < ${SKYRAY_PATH}/deploy-scripts/inference-service.sample.yaml | kubectl apply -n ${APP_NAMESPACE} -f -
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+envsubst < "${SCRIPT_DIR}/inference-service.sample.yaml" | kubectl apply -n ${APP_NAMESPACE} -f -
 kubectl label inferenceservices.serving.kserve.io/${INFERENCE_SERVICE_NAME} -n ${APP_NAMESPACE} app.kubernetes.io/instance=inferenceservice

--- a/deploy-scripts/deploy-kserve.sh
+++ b/deploy-scripts/deploy-kserve.sh
@@ -1,12 +1,14 @@
 # Nova is a K8s API that places workloads on other clusters — it cannot run pods.
-# We only install cert-manager CRDs here so helm can create Certificate/Issuer resources.
+# Disable cert-manager integration since Nova cannot run cert-manager webhooks.
 # Full cert-manager must already be running on the workload clusters.
-#
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.crds.yaml
+# NOTE: Since certManager.enabled=false, the helm chart won't render Certificate/Issuer
+# resources. On workload clusters where cert-manager IS running, you may need to create
+# KServe TLS certs separately if webhook validation requires them.
 #
 helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.17.0-rc0 $1
 helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0-rc0 \
  --set kserve.controller.deploymentMode=Standard \
+ --set kserve.certManager.enabled=false \
  -n kserve $1
 #
 # Label CRDs so Nova can duplicate them to all workload clusters

--- a/deploy-scripts/deploy-kserve.sh
+++ b/deploy-scripts/deploy-kserve.sh
@@ -1,4 +1,8 @@
-# Prerequisites: cert-manager must be installed (required by KServe webhooks)
+# Nova is a K8s API that places workloads on other clusters — it cannot run pods.
+# We only install cert-manager CRDs here so helm can create Certificate/Issuer resources.
+# Full cert-manager must already be running on the workload clusters.
+#
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.crds.yaml
 #
 helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.17.0-rc0 $1
 helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0-rc0 \

--- a/deploy-scripts/deploy-kserve.sh
+++ b/deploy-scripts/deploy-kserve.sh
@@ -1,7 +1,7 @@
 # Prerequisites: cert-manager must be installed (required by KServe webhooks)
 #
-helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.17.0 $1
-helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0 \
+helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.17.0-rc0 $1
+helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0-rc0 \
  --set kserve.controller.deploymentMode=Standard \
  -n kserve $1
 #

--- a/deploy-scripts/deploy-kserve.sh
+++ b/deploy-scripts/deploy-kserve.sh
@@ -5,6 +5,10 @@
 # resources. On workload clusters where cert-manager IS running, you may need to create
 # KServe TLS certs separately if webhook validation requires them.
 #
+# Clean up any orphaned cert-manager webhook configs that block API calls on Nova
+kubectl delete validatingwebhookconfiguration cert-manager-webhook 2>/dev/null || true
+kubectl delete mutatingwebhookconfiguration cert-manager-webhook 2>/dev/null || true
+#
 helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.17.0-rc0 $1
 helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0-rc0 \
  --set kserve.controller.deploymentMode=Standard \
@@ -19,6 +23,6 @@ kubectl label crd inferenceservices.serving.kserve.io        app.kubernetes.io/c
 kubectl label crd servingruntimes.serving.kserve.io          app.kubernetes.io/component=kserve
 kubectl label crd trainedmodels.serving.kserve.io            app.kubernetes.io/component=kserve
 #
-# Label operator resources in kserve namespace that may not already have app.kubernetes.io/name=kserve
-kubectl label cm/inferenceservice-config  -n kserve app.kubernetes.io/name=kserve
-kubectl label sa/kserve-controller-manager -n kserve app.kubernetes.io/name=kserve
+# Label operator resources in kserve namespace (--overwrite in case helm already set a different value)
+kubectl label cm/inferenceservice-config  -n kserve app.kubernetes.io/name=kserve --overwrite
+kubectl label sa/kserve-controller-manager -n kserve app.kubernetes.io/name=kserve --overwrite

--- a/deploy-scripts/deploy-kserve.sh
+++ b/deploy-scripts/deploy-kserve.sh
@@ -32,6 +32,17 @@ helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0-rc0 \
  --set kserve.certManager.enabled=false \
  -n kserve $1
 #
+# Delete KServe webhook configurations on the Nova control plane.
+# Nova cannot run pods, so these webhooks will never reach the controller and
+# block all InferenceService operations with timeout errors.
+# The webhooks will still function on workload clusters where the controller runs.
+kubectl delete mutatingwebhookconfiguration inferenceservice.serving.kserve.io 2>/dev/null || true
+kubectl delete validatingwebhookconfiguration clusterservingruntime.serving.kserve.io 2>/dev/null || true
+kubectl delete validatingwebhookconfiguration inferencegraph.serving.kserve.io 2>/dev/null || true
+kubectl delete validatingwebhookconfiguration inferenceservice.serving.kserve.io 2>/dev/null || true
+kubectl delete validatingwebhookconfiguration servingruntime.serving.kserve.io 2>/dev/null || true
+kubectl delete validatingwebhookconfiguration trainedmodel.serving.kserve.io 2>/dev/null || true
+#
 # Label CRDs so Nova can duplicate them to all workload clusters
 kubectl label crd clusterservingruntimes.serving.kserve.io   app.kubernetes.io/component=kserve
 kubectl label crd clusterstoragecontainers.serving.kserve.io app.kubernetes.io/component=kserve

--- a/deploy-scripts/deploy-kserve.sh
+++ b/deploy-scripts/deploy-kserve.sh
@@ -1,0 +1,18 @@
+# Prerequisites: cert-manager must be installed (required by KServe webhooks)
+#
+helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.17.0 $1
+helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0 \
+ --set kserve.controller.deploymentMode=Standard \
+ -n kserve $1
+#
+# Label CRDs so Nova can duplicate them to all workload clusters
+kubectl label crd clusterservingruntimes.serving.kserve.io   app.kubernetes.io/component=kserve
+kubectl label crd clusterstoragecontainers.serving.kserve.io app.kubernetes.io/component=kserve
+kubectl label crd inferencegraphs.serving.kserve.io          app.kubernetes.io/component=kserve
+kubectl label crd inferenceservices.serving.kserve.io        app.kubernetes.io/component=kserve
+kubectl label crd servingruntimes.serving.kserve.io          app.kubernetes.io/component=kserve
+kubectl label crd trainedmodels.serving.kserve.io            app.kubernetes.io/component=kserve
+#
+# Label operator resources in kserve namespace that may not already have app.kubernetes.io/name=kserve
+kubectl label cm/inferenceservice-config  -n kserve app.kubernetes.io/name=kserve
+kubectl label sa/kserve-controller-manager -n kserve app.kubernetes.io/name=kserve

--- a/deploy-scripts/deploy-kserve.sh
+++ b/deploy-scripts/deploy-kserve.sh
@@ -1,15 +1,32 @@
 # Nova is a K8s API that places workloads on other clusters — it cannot run pods.
 # Disable cert-manager integration since Nova cannot run cert-manager webhooks.
 # Full cert-manager must already be running on the workload clusters.
-# NOTE: Since certManager.enabled=false, the helm chart won't render Certificate/Issuer
-# resources. On workload clusters where cert-manager IS running, you may need to create
-# KServe TLS certs separately if webhook validation requires them.
 #
 # Clean up any orphaned cert-manager webhook configs that block API calls on Nova
 kubectl delete validatingwebhookconfiguration cert-manager-webhook 2>/dev/null || true
 kubectl delete mutatingwebhookconfiguration cert-manager-webhook 2>/dev/null || true
 #
 helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.17.0-rc0 $1
+#
+# Create kserve namespace before generating the webhook cert secret
+kubectl create namespace kserve 2>/dev/null || true
+#
+# Generate a self-signed TLS cert for the KServe webhook since cert-manager is disabled.
+# The controller deployment mounts secret "kserve-webhook-server-cert" as a volume.
+TMP_CERT_DIR=$(mktemp -d)
+openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+  -keyout "${TMP_CERT_DIR}/tls.key" \
+  -out "${TMP_CERT_DIR}/tls.crt" \
+  -subj "/CN=kserve-webhook-server-service.kserve.svc" \
+  -addext "subjectAltName=DNS:kserve-webhook-server-service.kserve.svc,DNS:kserve-webhook-server-service.kserve.svc.cluster.local" \
+  2>/dev/null
+kubectl delete secret kserve-webhook-server-cert -n kserve 2>/dev/null || true
+kubectl create secret tls kserve-webhook-server-cert -n kserve \
+  --cert="${TMP_CERT_DIR}/tls.crt" \
+  --key="${TMP_CERT_DIR}/tls.key"
+kubectl label secret kserve-webhook-server-cert -n kserve app.kubernetes.io/name=kserve
+rm -rf "${TMP_CERT_DIR}"
+#
 helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0-rc0 \
  --set kserve.controller.deploymentMode=Standard \
  --set kserve.certManager.enabled=false \

--- a/deploy-scripts/inference-service.sample.yaml
+++ b/deploy-scripts/inference-service.sample.yaml
@@ -1,0 +1,12 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: ${INFERENCE_SERVICE_NAME}
+  labels:
+    app.kubernetes.io/instance: inferenceservice
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: sklearn
+      storageUri: gs://kfserving-examples/models/sklearn/1.0/model

--- a/deploy-scripts/kservenamespace.yaml
+++ b/deploy-scripts/kservenamespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kserve
+  labels:
+    app: kserve

--- a/deploy-scripts/undeploy-kserve.sh
+++ b/deploy-scripts/undeploy-kserve.sh
@@ -7,3 +7,7 @@ kubectl delete crd inferencegraphs.serving.kserve.io
 kubectl delete crd inferenceservices.serving.kserve.io
 kubectl delete crd servingruntimes.serving.kserve.io
 kubectl delete crd trainedmodels.serving.kserve.io
+#
+# Remove cert-manager CRDs that were installed for Nova control plane
+# WARNING: only delete if no other operators depend on cert-manager CRDs
+kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.crds.yaml

--- a/deploy-scripts/undeploy-kserve.sh
+++ b/deploy-scripts/undeploy-kserve.sh
@@ -1,0 +1,9 @@
+helm uninstall kserve -n kserve $1
+helm uninstall kserve-crd $1
+#
+kubectl delete crd clusterservingruntimes.serving.kserve.io
+kubectl delete crd clusterstoragecontainers.serving.kserve.io
+kubectl delete crd inferencegraphs.serving.kserve.io
+kubectl delete crd inferenceservices.serving.kserve.io
+kubectl delete crd servingruntimes.serving.kserve.io
+kubectl delete crd trainedmodels.serving.kserve.io

--- a/deploy-scripts/undeploy-kserve.sh
+++ b/deploy-scripts/undeploy-kserve.sh
@@ -7,7 +7,3 @@ kubectl delete crd inferencegraphs.serving.kserve.io
 kubectl delete crd inferenceservices.serving.kserve.io
 kubectl delete crd servingruntimes.serving.kserve.io
 kubectl delete crd trainedmodels.serving.kserve.io
-#
-# Remove cert-manager CRDs that were installed for Nova control plane
-# WARNING: only delete if no other operators depend on cert-manager CRDs
-kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.crds.yaml

--- a/deploy-scripts/undeploy-kserve.sh
+++ b/deploy-scripts/undeploy-kserve.sh
@@ -1,6 +1,8 @@
 helm uninstall kserve -n kserve $1
 helm uninstall kserve-crd $1
 #
+kubectl delete secret kserve-webhook-server-cert -n kserve 2>/dev/null || true
+#
 kubectl delete crd clusterservingruntimes.serving.kserve.io
 kubectl delete crd clusterstoragecontainers.serving.kserve.io
 kubectl delete crd inferencegraphs.serving.kserve.io

--- a/policies/inferenceservicensprioritypolicy.yaml
+++ b/policies/inferenceservicensprioritypolicy.yaml
@@ -3,13 +3,16 @@ kind: SchedulePolicy
 metadata:
   name: inferenceservice-policy-${APP_NAMESPACE}
 spec:
-  orderedClusterSelector:
-    matchExpressions:
-      - key: kubernetes.io/metadata.name
-        operator: In
-        values:
-          - onprem
-          - cloud
+  clusterSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: kind-workload-2
+  #orderedClusterSelector:
+  #  matchExpressions:
+  #    - key: kubernetes.io/metadata.name
+  #      operator: In
+  #      values:
+  #        - onprem
+  #        - cloud
   namespaceSelector:
     matchLabels:
       kubernetes.io/metadata.name: ${APP_NAMESPACE}

--- a/policies/inferenceservicensprioritypolicy.yaml
+++ b/policies/inferenceservicensprioritypolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: policy.elotl.co/v1alpha1
+kind: SchedulePolicy
+metadata:
+  name: inferenceservice-policy-${APP_NAMESPACE}
+spec:
+  orderedClusterSelector:
+    matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values:
+          - onprem
+          - cloud
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: ${APP_NAMESPACE}
+  resourceSelectors:
+    labelSelectors:
+    - matchLabels:
+        app.kubernetes.io/instance: ${APP_INSTANCE_NAME}
+  groupBy:
+    labelKey: app.kubernetes.io/instance

--- a/policies/inferenceservicepolicy.yaml
+++ b/policies/inferenceservicepolicy.yaml
@@ -1,0 +1,16 @@
+apiVersion: policy.elotl.co/v1alpha1
+kind: SchedulePolicy
+metadata:
+  name: inferenceservice-policy
+spec:
+  clusterSelector:
+    matchLabels:
+      nova.elotl.co/cluster.region: "us-west-2"
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: Exists
+  resourceSelectors:
+    labelSelectors:
+    - matchLabels:
+        app.kubernetes.io/instance: inferenceservice

--- a/policies/inferenceservicepolicy.yaml
+++ b/policies/inferenceservicepolicy.yaml
@@ -5,7 +5,10 @@ metadata:
 spec:
   clusterSelector:
     matchLabels:
-      nova.elotl.co/cluster.region: "us-west-2"
+      kubernetes.io/metadata.name: kind-workload-2
+  #clusterSelector:
+  #  matchLabels:
+  #    nova.elotl.co/cluster.region: "us-west-2"
   namespaceSelector:
     matchExpressions:
     - key: kubernetes.io/metadata.name

--- a/policies/kservecrdpolicy.yaml
+++ b/policies/kservecrdpolicy.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy.elotl.co/v1alpha1
+kind: SchedulePolicy
+metadata:
+  name: kserve-crd-policy
+spec:
+  spreadConstraints:
+    spreadMode: Duplicate
+    topologyKey: kubernetes.io/metadata.name
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: Exists
+  resourceSelectors:
+    labelSelectors:
+    - matchLabels:
+        app.kubernetes.io/component: kserve
+  groupBy:
+    labelKey: app.kubernetes.io/component

--- a/policies/kservenspolicy.yaml
+++ b/policies/kservenspolicy.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy.elotl.co/v1alpha1
+kind: SchedulePolicy
+metadata:
+  name: kserve-ns-policy
+spec:
+  spreadConstraints:
+    spreadMode: Duplicate
+    topologyKey: kubernetes.io/metadata.name
+  resourceSelectors:
+    labelSelectors:
+    - matchLabels:
+        app: kserve
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: Exists
+  groupBy:
+    labelKey: app

--- a/policies/kservepolicy.yaml
+++ b/policies/kservepolicy.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy.elotl.co/v1alpha1
+kind: SchedulePolicy
+metadata:
+  name: kserve-policy
+spec:
+  spreadConstraints:
+    spreadMode: Duplicate
+    topologyKey: kubernetes.io/metadata.name
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: Exists
+  resourceSelectors:
+    labelSelectors:
+    - matchLabels:
+        app.kubernetes.io/name: kserve
+  groupBy:
+    labelKey: app.kubernetes.io/name


### PR DESCRIPTION
### Deploy Scripts:
-  `deploy-scripts/deploy-kserve.sh`  — Installs  kserve-crd  and  kserve  helm charts, labels all 6 KServe CRDs with  app.kubernetes.io/component=kserve , and labels unlabeled operator resources (ConfigMap, ServiceAccount) with  app.kubernetes.io/name=kserve . Includes cert-manager prerequisite note.
-  `deploy-scripts/undeploy-kserve.sh`  — Uninstalls both helm charts and deletes all CRDs.
-  `deploy-scripts/deploy-inferenceservice.sh`  — Deploys an InferenceService CR and labels it with  app.kubernetes.io/instance=inferenceservice .
-  `deploy-scripts/inference-service.sample.yaml`  — Sample InferenceService CR template with  ${INFERENCE_SERVICE_NAME}  envsubst.
-  `deploy-scripts/kservenamespace.yaml`  — Namespace template with  app: kserve  label (follows  namespace.yaml / appnamespace.yaml  convention).

### Nova Policies (Duplicate to all clusters):
-  `policies/kservecrdpolicy.yaml`  — Spreads KServe CRDs to all workload clusters (matches  app.kubernetes.io/component: kserve )
-  `policies/kservenspolicy.yaml`  — Spreads the  kserve  namespace to all clusters (matches  app: kserve )
-  `policies/kservepolicy.yaml`  — Spreads KServe controller/components to all clusters (matches  app.kubernetes.io/name: kserve )

### Nova Policies (InferenceService placement):
-  `policies/inferenceservicepolicy.yaml`  — Places InferenceService CRs to a specific cluster

### Remarks:
1. [FIXED]: I am at the stage of running (making work) `bash deploy-scripts/deploy-kserve.sh`

I had to use [v0.17.0-rc1](https://github.com/orgs/kserve/packages/container/charts%2Fkserve-crd/732480128?tag=v0.17.0-rc1), because for [v0.17.0](https://github.com/orgs/kserve/packages/container/charts%2Fkserve-crd/735444764?tag=v0.17.0) I was getting 
```
Error: INSTALLATION FAILED: failed to perform "FetchReference" on source: ghcr.io/kserve/charts/kserve:v0.17.0: not found
```

For the `v0.17.9-rc1` I am getting cert manager errors as If I needed a fully functional cert manager in nova 
```
Digest: sha256:c378c6e26e3bbc81d5f508e3133d023cec0b82b0787bc0cba64e0433a00884a7
Error: INSTALLATION FAILED: Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://cert-manager-webhook.cert-manager.svc:443/validate?timeout=30s": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://cert-manager-webhook.cert-manager.svc:443/validate?timeout=30s": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

--> `kserve               pod/kserve-controller-manager-68bc9f9d78-l2pfj         0/2     ContainerCreating   0             2m18s` on both workload clusters, but 

```
Events:
  Type     Reason       Age                  From               Message
  ----     ------       ----                 ----               -------
  Normal   Scheduled    3m47s                default-scheduler  Successfully assigned kserve/kserve-controller-manager-68bc9f9d78-l2pfj to workload-1-control-plane
  Warning  FailedMount  99s (x9 over 3m47s)  kubelet            MountVolume.SetUp failed for volume "cert" : secret "kserve-webhook-server-cert" not found
```

Addinhg self signed certs solved the problem for now :) 
```
kserve               pod/kserve-controller-manager-68bc9f9d78-7fbrv         2/2     Running   0               75m
```